### PR TITLE
Replace hardcoded hex colors with editorial CSS vars in ErrorBoundary and OfflineIndicator

### DIFF
--- a/website/src/components/ErrorBoundary.tsx
+++ b/website/src/components/ErrorBoundary.tsx
@@ -76,7 +76,7 @@ function DefaultErrorFallback({ error, onRetry }: DefaultErrorFallbackProps): Re
         style={{
           width: 64,
           height: 64,
-          backgroundColor: '#fee2e2',
+          backgroundColor: 'var(--theme-error-bg)',
           borderRadius: '50%',
           display: 'flex',
           alignItems: 'center',
@@ -85,7 +85,7 @@ function DefaultErrorFallback({ error, onRetry }: DefaultErrorFallbackProps): Re
         }}
       >
         <svg
-          style={{ width: 32, height: 32, color: '#dc2626' }}
+          style={{ width: 32, height: 32, color: 'var(--theme-error)' }}
           fill="none"
           stroke="currentColor"
           viewBox="0 0 24 24"
@@ -103,7 +103,7 @@ function DefaultErrorFallback({ error, onRetry }: DefaultErrorFallbackProps): Re
         style={{
           fontSize: 24,
           fontWeight: 600,
-          color: '#111827',
+          color: 'var(--editorial-ink)',
           marginBottom: 8
         }}
       >
@@ -112,7 +112,7 @@ function DefaultErrorFallback({ error, onRetry }: DefaultErrorFallbackProps): Re
 
       <p
         style={{
-          color: '#6b7280',
+          color: 'var(--editorial-muted)',
           marginBottom: 24,
           maxWidth: 400
         }}
@@ -123,11 +123,11 @@ function DefaultErrorFallback({ error, onRetry }: DefaultErrorFallbackProps): Re
       {error !== null && process.env.NODE_ENV === 'development' ? (
         <pre
           style={{
-            backgroundColor: '#f3f4f6',
+            backgroundColor: 'var(--editorial-paper)',
             padding: 16,
             borderRadius: 8,
             fontSize: 12,
-            color: '#dc2626',
+            color: 'var(--theme-error)',
             marginBottom: 24,
             maxWidth: '100%',
             overflow: 'auto',
@@ -139,38 +139,24 @@ function DefaultErrorFallback({ error, onRetry }: DefaultErrorFallbackProps): Re
       ) : null}
 
       <div style={{ display: 'flex', gap: 12 }}>
-        <button
-          onClick={onRetry}
-          style={{
-            backgroundColor: '#2563eb',
-            color: 'white',
-            fontWeight: 500,
-            padding: '12px 24px',
-            borderRadius: 8,
-            border: 'none',
-            cursor: 'pointer',
-            transition: 'background-color 0.2s'
-          }}
-          onMouseOver={(e) => (e.currentTarget.style.backgroundColor = '#1d4ed8')}
-          onMouseOut={(e) => (e.currentTarget.style.backgroundColor = '#2563eb')}
-        >
+        <button onClick={onRetry} className="btn-primary">
           Try Again
         </button>
 
         <button
           onClick={() => (window.location.href = '/')}
           style={{
-            backgroundColor: '#f3f4f6',
-            color: '#374151',
+            backgroundColor: 'var(--editorial-paper)',
+            color: 'var(--editorial-ink)',
             fontWeight: 500,
             padding: '12px 24px',
             borderRadius: 8,
-            border: '1px solid #d1d5db',
+            border: '1px solid var(--editorial-rule)',
             cursor: 'pointer',
             transition: 'background-color 0.2s'
           }}
-          onMouseOver={(e) => (e.currentTarget.style.backgroundColor = '#e5e7eb')}
-          onMouseOut={(e) => (e.currentTarget.style.backgroundColor = '#f3f4f6')}
+          onMouseOver={(e) => (e.currentTarget.style.backgroundColor = 'var(--theme-background-hover)')}
+          onMouseOut={(e) => (e.currentTarget.style.backgroundColor = 'var(--editorial-paper)')}
         >
           Go Home
         </button>

--- a/website/src/components/OfflineIndicator.tsx
+++ b/website/src/components/OfflineIndicator.tsx
@@ -2,18 +2,9 @@
 
 import React from 'react'
 import { useOnlineStatus } from '@/hooks/useOnlineStatus'
-import { useThemeContext } from '@/components/TamaguiProvider'
-
-// Warning colors that work well in both light and dark modes
-const warningColors = {
-  light: { bg: '#fbbf24', text: '#78350f' }, // amber-400, amber-900
-  dark: { bg: '#d97706', text: '#fffbeb' } // amber-600, amber-50
-}
 
 export function OfflineIndicator() {
   const isOnline = useOnlineStatus()
-  const { theme } = useThemeContext()
-  const colors = warningColors[theme]
 
   if (isOnline) {
     return null
@@ -24,7 +15,7 @@ export function OfflineIndicator() {
     top: 0,
     left: 0,
     right: 0,
-    backgroundColor: colors.bg,
+    backgroundColor: 'var(--theme-warning)',
     padding: '8px 16px',
     display: 'flex',
     flexDirection: 'row',
@@ -41,7 +32,7 @@ export function OfflineIndicator() {
         height={16}
         viewBox="0 0 24 24"
         fill="none"
-        stroke={colors.text}
+        stroke="var(--theme-warning-text)"
         strokeWidth={2}
         strokeLinecap="round"
         strokeLinejoin="round"
@@ -54,7 +45,7 @@ export function OfflineIndicator() {
         <path d="M8.53 16.11a6 6 0 0 1 6.95 0" />
         <line x1="12" y1="20" x2="12.01" y2="20" />
       </svg>
-      <span style={{ color: colors.text, fontSize: 14, fontWeight: 600 }}>
+      <span style={{ color: 'var(--theme-warning-text)', fontSize: 14, fontWeight: 600 }}>
         You are offline
       </span>
     </div>


### PR DESCRIPTION
## Summary

- **ErrorBoundary**: replaced 10 hardcoded hex values with editorial/theme CSS custom properties. Error icon circle → `var(--theme-error-bg)`, SVG and pre text → `var(--theme-error)`, heading → `var(--editorial-ink)`, subtext → `var(--editorial-muted)`, pre background → `var(--editorial-paper)`, "Go Home" button bg/border/hover → `var(--editorial-paper)` / `var(--editorial-rule)` / `var(--theme-background-hover)`. "Try Again" button converted to `className="btn-primary"`.
- **OfflineIndicator**: removed the `warningColors` object and `useThemeContext` import/usage; banner background → `var(--theme-warning)`, icon stroke and text → `var(--theme-warning-text)`. Dark-mode overrides are already handled by `html.t_dark` in `design-tokens.css`.

## Test plan

- [x] `npm run lint` — clean
- [x] `npm test` — 49/49 passing
- [ ] Manually verify error state renders correctly in light and dark modes
- [ ] Manually verify offline banner renders correctly in light and dark modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)