### PR TITLE
Editorial UI iteration: single Start CTA, settings cog, polish

### DIFF
--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -240,6 +240,42 @@ input[type="radio"] {
 html.t_dark .theme-icon-sun { display: flex; align-items: center; justify-content: center; line-height: 0; }
 html.t_dark .theme-icon-moon { display: none; }
 
+/* Editorial stats strip — top/bottom hairlines + inter-cell rules that follow the actual column count */
+.stats-strip {
+  display: grid;
+  grid-template-columns: 1fr;
+  border-top: 1px solid var(--editorial-rule);
+  border-bottom: 1px solid var(--editorial-rule);
+}
+
+.stats-strip-cell {
+  padding: 24px 20px;
+}
+
+/* 1-column (mobile): row separators between stacked cells */
+.stats-strip-cell + .stats-strip-cell {
+  border-top: 1px solid var(--editorial-rule);
+}
+
+@media (min-width: 480px) {
+  .stats-strip { grid-template-columns: 1fr 1fr; }
+  /* clear the mobile row separator */
+  .stats-strip-cell + .stats-strip-cell { border-top: none; }
+  /* row separator only between rows (cells 3+) */
+  .stats-strip-cell:nth-child(n+3) { border-top: 1px solid var(--editorial-rule); }
+  /* column separator only on the right column */
+  .stats-strip-cell:nth-child(2n) { border-left: 1px solid var(--editorial-rule); }
+}
+
+@media (min-width: 768px) {
+  .stats-strip { grid-template-columns: repeat(4, 1fr); }
+  /* clear tablet rules */
+  .stats-strip-cell:nth-child(n+3) { border-top: none; }
+  .stats-strip-cell:nth-child(2n) { border-left: none; }
+  /* column separator between every adjacent pair of cells */
+  .stats-strip-cell + .stats-strip-cell { border-left: 1px solid var(--editorial-rule); }
+}
+
 /* Dark mode improvements */
 html.t_dark .progress-bar {
   box-shadow: 0 2px 4px rgba(59, 130, 246, 0.5);

--- a/website/src/app/globals.css
+++ b/website/src/app/globals.css
@@ -236,8 +236,8 @@ input[type="radio"] {
 
 /* Theme toggle icon switching - CSS controls visibility so server/client HTML matches */
 .theme-icon-sun { display: none; }
-.theme-icon-moon { display: block; }
-html.t_dark .theme-icon-sun { display: block; }
+.theme-icon-moon { display: flex; align-items: center; justify-content: center; line-height: 0; }
+html.t_dark .theme-icon-sun { display: flex; align-items: center; justify-content: center; line-height: 0; }
 html.t_dark .theme-icon-moon { display: none; }
 
 /* Dark mode improvements */

--- a/website/src/app/page.tsx
+++ b/website/src/app/page.tsx
@@ -51,21 +51,24 @@ export default function Home() {
     earlyWins: 0,
     earlyFailures: 0
   })
+  const [hasConfigured, setHasConfigured] = useState(false)
   const [isLoading, setIsLoading] = useState(true)
 
   useEffect(() => {
     let mounted = true
 
-    const loadStats = Effect.gen(function* () {
+    const loadHomeData = Effect.gen(function* () {
       const storageService = yield* LocalStorageService
       const gameStats = yield* storageService.getGameStats()
+      const settingsConfigured = yield* storageService.hasSavedSettings()
       if (mounted) {
         setStats(gameStats)
+        setHasConfigured(settingsConfigured)
         setIsLoading(false)
       }
     })
 
-    Effect.runPromise(loadStats.pipe(Effect.provide(LocalStorageService.Default))).catch(
+    Effect.runPromise(loadHomeData.pipe(Effect.provide(LocalStorageService.Default))).catch(
       (error) => {
         if (mounted) {
           console.error(error)
@@ -205,36 +208,13 @@ export default function Home() {
                 <Keyboard size={13} strokeWidth={1.5} /> Keyboard
               </span>
             </div>
-            <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
-              <button
-                onClick={() => router.push('/settings')}
-                className="btn-primary focus-ring"
-                style={{
-                  width: '100%',
-                  padding: '11px 20px',
-                  borderRadius: 5,
-                  fontWeight: 600,
-                  fontSize: 14,
-                  cursor: 'pointer',
-                }}
-              >
-                Customize &amp; Start
-              </button>
-              <button
-                onClick={() => router.push('/game')}
-                className="btn-secondary focus-ring"
-                style={{
-                  width: '100%',
-                  padding: '9px 16px',
-                  borderRadius: 5,
-                  fontWeight: 500,
-                  fontSize: 13,
-                  cursor: 'pointer',
-                }}
-              >
-                Quick Start
-              </button>
-            </div>
+            <button
+              onClick={() => router.push(hasConfigured ? '/game' : '/settings')}
+              className="btn-editorial focus-ring"
+              style={{ width: '100%' }}
+            >
+              Start
+            </button>
           </div>
 
           {/* View Results */}
@@ -273,16 +253,8 @@ export default function Home() {
             </p>
             <button
               onClick={() => router.push('/results')}
-              className="btn-primary focus-ring"
-              style={{
-                width: '100%',
-                padding: '11px 20px',
-                borderRadius: 5,
-                fontWeight: 600,
-                fontSize: 14,
-                cursor: 'pointer',
-                marginTop: 'auto',
-              }}
+              className="btn-editorial-ghost focus-ring"
+              style={{ width: '100%', marginTop: 'auto' }}
             >
               View Results
             </button>

--- a/website/src/app/results/page.tsx
+++ b/website/src/app/results/page.tsx
@@ -82,12 +82,6 @@ export default function Results() {
     return 'Failed'
   }
 
-  const getScoreColor = (percentage: number): string => {
-    if (percentage >= 80) return 'var(--theme-success)'
-    if (percentage >= 60) return 'var(--theme-primary)'
-    return 'var(--theme-error)'
-  }
-
   if (isLoading) {
     return (
       <Layout title="Loading Results...">
@@ -98,50 +92,64 @@ export default function Results() {
     )
   }
 
-  const cardStyle: React.CSSProperties = {
-    backgroundColor: 'var(--theme-card-bg)',
-    border: '1px solid var(--editorial-rule)',
-    borderRadius: 8,
+  const eyebrowStyle: React.CSSProperties = {
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: '0.12em',
+    textTransform: 'uppercase',
+    color: 'var(--editorial-accent)',
+    marginBottom: 10,
+  }
+
+  const sectionTitleStyle: React.CSSProperties = {
+    fontFamily: 'var(--font-family-serif)',
+    fontSize: 22,
+    fontWeight: 500,
+    color: 'var(--editorial-ink)',
+    letterSpacing: '-0.01em',
+  }
+
+  const clearButtonStyle: React.CSSProperties = {
+    background: 'none',
+    border: 'none',
+    padding: '6px 4px',
+    fontSize: 13,
+    color: 'var(--editorial-muted)',
+    textDecoration: 'underline',
+    cursor: 'pointer',
+    fontFamily: 'inherit',
   }
 
   return (
     <Layout title="Test Results">
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 32 }}>
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 16 }}>
-          <h1 style={{ fontFamily: 'var(--font-family-serif)', fontSize: 'clamp(1.5rem, 4vw, 2rem)', fontWeight: 500, color: 'var(--editorial-ink)', letterSpacing: '-0.01em' }}>
-            Your Test Results
-          </h1>
-          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 32, maxWidth: 900, margin: '0 auto' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-end', flexWrap: 'wrap', gap: 16 }}>
+          <div>
+            <p style={eyebrowStyle}>Archive</p>
+            <h1 style={{ fontFamily: 'var(--font-family-serif)', fontSize: 'clamp(2rem, 5vw, 2.75rem)', fontWeight: 500, color: 'var(--editorial-ink)', letterSpacing: '-0.02em', lineHeight: 1.1 }}>
+              Your Test Results
+            </h1>
+          </div>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
             <button
               onClick={() => (window.location.href = '/statistics')}
-              className="btn-purple focus-ring"
-              style={{ padding: '7px 14px', borderRadius: 6, fontWeight: 500, fontSize: 14, cursor: 'pointer' }}
+              className="btn-editorial-ghost focus-ring"
             >
               View Question Stats
             </button>
             <button
               onClick={() => (window.location.href = '/game')}
-              className="btn-primary focus-ring"
-              style={{ padding: '7px 14px', borderRadius: 6, fontWeight: 500, fontSize: 14, cursor: 'pointer' }}
+              className="btn-editorial focus-ring"
             >
               Take New Test
             </button>
-            {results.length > 0 ? (
-              <button
-                onClick={handleClearData}
-                className="btn-error focus-ring"
-                style={{ padding: '7px 14px', borderRadius: 6, fontWeight: 500, fontSize: 14, cursor: 'pointer' }}
-              >
-                Clear All Data
-              </button>
-            ) : null}
           </div>
         </div>
 
         <StatsSummary stats={stats} />
 
         {results.length === 0 ? (
-          <div style={{ ...cardStyle, padding: 40, textAlign: 'center' }}>
+          <div style={{ borderTop: '1px solid var(--editorial-rule)', padding: '48px 16px 16px', textAlign: 'center' }}>
             <div style={{
               width: 56,
               height: 56,
@@ -150,45 +158,45 @@ export default function Results() {
               display: 'flex',
               alignItems: 'center',
               justifyContent: 'center',
-              margin: '0 auto 16px'
+              margin: '0 auto 20px'
             }}>
-              <FileText size={28} strokeWidth={1.5} color="var(--editorial-accent)" />
+              <FileText size={26} strokeWidth={1.5} color="var(--editorial-accent)" />
             </div>
-            <h3 style={{ fontSize: 18, fontWeight: 600, color: 'var(--editorial-ink)', marginBottom: 8 }}>
+            <p style={{ ...eyebrowStyle, marginBottom: 8 }}>Archive</p>
+            <h3 style={{ ...sectionTitleStyle, marginBottom: 10 }}>
               No Test Results Yet
             </h3>
-            <p style={{ color: 'var(--editorial-muted)', marginBottom: 24 }}>
+            <p style={{ color: 'var(--editorial-muted)', marginBottom: 24, fontSize: 14, lineHeight: 1.6 }}>
               You haven&apos;t taken any civics tests yet. Take your first test to see your results here.
             </p>
             <button
               onClick={() => (window.location.href = '/game')}
-              className="btn-primary focus-ring"
-              style={{ padding: '10px 24px', borderRadius: 6, fontWeight: 500, cursor: 'pointer' }}
+              className="btn-editorial focus-ring"
             >
               Take Your First Test
             </button>
           </div>
         ) : (
-          <div style={{ ...cardStyle, overflow: 'hidden' }}>
-            <div style={{ padding: '14px 24px', borderBottom: '1px solid var(--editorial-rule)' }}>
-              <h3 style={{ fontSize: 16, fontWeight: 600, color: 'var(--editorial-ink)' }}>
-                Test History ({results.length} tests)
-              </h3>
+          <div>
+            <div style={{ borderTop: '1px solid var(--editorial-rule)', paddingTop: 20, marginBottom: 0 }}>
+              <p style={eyebrowStyle}>Archive · {results.length} {results.length === 1 ? 'Test' : 'Tests'}</p>
+              <h3 style={{ ...sectionTitleStyle, marginBottom: 16 }}>Test History</h3>
+              <div style={{ borderTop: '1px solid var(--editorial-rule)' }} />
             </div>
             <div>
               {results.map((result, index) => (
                 <div
                   key={result.sessionId}
                   style={{
-                    padding: '14px 24px',
-                    borderBottom: index < results.length - 1 ? '1px solid var(--editorial-rule)' : undefined,
+                    padding: '18px 0',
+                    borderBottom: '1px solid var(--editorial-rule)',
                   }}
                   className="results-row"
                 >
                   <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 16 }}>
                     <div style={{ flex: 1 }}>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6, flexWrap: 'wrap' }}>
-                        <span style={{ fontSize: 14, fontWeight: 500, color: 'var(--editorial-ink)' }}>
+                      <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 8, flexWrap: 'wrap' }}>
+                        <span style={{ fontSize: 13, fontWeight: 500, color: 'var(--editorial-ink)', letterSpacing: '0.02em' }}>
                           Test #{results.length - index}
                         </span>
                         <span className={getBadgeClass(result)}>
@@ -199,34 +207,41 @@ export default function Results() {
                           {result.completedAt.toLocaleTimeString()}
                         </span>
                       </div>
-                      <div style={{ display: 'flex', alignItems: 'center', gap: 20, fontSize: 14 }}>
-                        <span style={{ fontWeight: 600, color: getScoreColor(result.percentage) }}>
+                      <div style={{ display: 'flex', alignItems: 'baseline', gap: 16, fontSize: 14, flexWrap: 'wrap' }}>
+                        <span style={{
+                          fontFamily: 'var(--font-family-serif)',
+                          fontSize: 24,
+                          fontWeight: 500,
+                          color: result.percentage >= 60 ? 'var(--editorial-ink)' : 'var(--theme-error)',
+                          letterSpacing: '-0.02em',
+                          lineHeight: 1,
+                        }}>
                           {result.percentage}%
                         </span>
-                        <span style={{ color: 'var(--editorial-muted)' }}>
+                        <span style={{ color: 'var(--editorial-muted)', fontSize: 13 }}>
                           {result.correctAnswers}/{result.totalQuestions} correct
                         </span>
                         {result.isEarlyWin === true ? (
-                          <span style={{ color: 'var(--theme-warning)', fontSize: 12, display: 'flex', alignItems: 'center', gap: 3 }}>
+                          <span style={{ color: 'var(--editorial-accent)', fontSize: 12, display: 'flex', alignItems: 'center', gap: 4 }}>
                             <Star size={12} strokeWidth={1.5} />
                             Early completion
                           </span>
                         ) : null}
                       </div>
                     </div>
-                    <div style={{ flexShrink: 0, position: 'relative', width: 56, height: 56 }}>
-                      <svg style={{ width: 56, height: 56, transform: 'rotate(-90deg)', position: 'absolute', top: 0, left: 0 }} viewBox="0 0 36 36">
+                    <div style={{ flexShrink: 0, position: 'relative', width: 52, height: 52 }}>
+                      <svg style={{ width: 52, height: 52, transform: 'rotate(-90deg)', position: 'absolute', top: 0, left: 0 }} viewBox="0 0 36 36">
                         <path
                           d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
                           fill="none"
                           stroke="var(--editorial-rule)"
-                          strokeWidth="3"
+                          strokeWidth="2"
                         />
                         <path
                           d="M18 2.0845 a 15.9155 15.9155 0 0 1 0 31.831 a 15.9155 15.9155 0 0 1 0 -31.831"
                           fill="none"
-                          stroke={result.percentage >= 60 ? 'var(--theme-success)' : 'var(--theme-error)'}
-                          strokeWidth="3"
+                          stroke={result.percentage >= 60 ? 'var(--editorial-accent)' : 'var(--theme-error)'}
+                          strokeWidth="2"
                           strokeDasharray={`${result.percentage}, 100`}
                         />
                       </svg>
@@ -235,9 +250,10 @@ export default function Results() {
                         top: '50%',
                         left: '50%',
                         transform: 'translate(-50%, -50%)',
+                        fontFamily: 'var(--font-family-serif)',
                         fontSize: 11,
-                        fontWeight: 'bold',
-                        color: getScoreColor(result.percentage),
+                        fontWeight: 500,
+                        color: 'var(--editorial-ink)',
                       }}>
                         {result.percentage}%
                       </span>
@@ -245,6 +261,11 @@ export default function Results() {
                   </div>
                 </div>
               ))}
+            </div>
+            <div style={{ paddingTop: 16, display: 'flex', justifyContent: 'flex-end' }}>
+              <button onClick={handleClearData} className="focus-ring" style={clearButtonStyle}>
+                Clear all data
+              </button>
             </div>
           </div>
         )}

--- a/website/src/app/statistics/page.tsx
+++ b/website/src/app/statistics/page.tsx
@@ -104,12 +104,48 @@ export default function Statistics() {
     }
   }
 
-  const cardStyle: React.CSSProperties = {
-    backgroundColor: 'var(--theme-card-bg)',
-    border: '1px solid var(--editorial-rule)',
-    borderRadius: 8,
-    padding: 24,
+  const eyebrowStyle: React.CSSProperties = {
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: '0.12em',
+    textTransform: 'uppercase',
+    color: 'var(--editorial-accent)',
+    marginBottom: 10,
   }
+
+  const statValueStyle: React.CSSProperties = {
+    fontFamily: 'var(--font-family-serif)',
+    fontSize: 'clamp(2rem, 4vw, 2.5rem)',
+    fontWeight: 500,
+    color: 'var(--editorial-ink)',
+    letterSpacing: '-0.02em',
+    lineHeight: 1,
+    display: 'block',
+    marginBottom: 6,
+  }
+
+  const statLabelStyle: React.CSSProperties = {
+    fontSize: 11,
+    fontWeight: 600,
+    letterSpacing: '0.08em',
+    textTransform: 'uppercase',
+    color: 'var(--editorial-muted)',
+    display: 'block',
+    marginBottom: 6,
+  }
+
+  const statHelperStyle: React.CSSProperties = {
+    fontSize: 12,
+    color: 'var(--editorial-muted)',
+    marginTop: 6,
+  }
+
+  const summaryCells = [
+    { label: 'Total Questions', value: summary.totalQuestions, helper: undefined as string | undefined },
+    { label: 'Attempted', value: summary.questionsAttempted, helper: undefined },
+    { label: 'Mastered', value: summary.questionsMastered, helper: '3+ consecutive correct' },
+    { label: 'Need Practice', value: summary.questionsNeedingPractice, helper: '<60% accuracy' },
+  ]
 
   if (isLoading) {
     return (
@@ -126,64 +162,48 @@ export default function Statistics() {
 
   return (
     <Layout title="Question Statistics">
-      <div style={{ display: 'flex', flexDirection: 'column', gap: 24 }}>
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 32, maxWidth: 1100, margin: '0 auto' }}>
         <div>
-          <h1 style={{ fontFamily: 'var(--font-family-serif)', fontSize: 'clamp(1.5rem, 4vw, 2rem)', fontWeight: 500, color: 'var(--editorial-ink)', letterSpacing: '-0.01em', marginBottom: 6 }}>
+          <p style={eyebrowStyle}>Performance · Civics Questions</p>
+          <h1 style={{ fontFamily: 'var(--font-family-serif)', fontSize: 'clamp(2rem, 5vw, 2.75rem)', fontWeight: 500, color: 'var(--editorial-ink)', letterSpacing: '-0.02em', lineHeight: 1.1, marginBottom: 10 }}>
             Question Statistics
           </h1>
-          <p style={{ color: 'var(--editorial-muted)', fontSize: 14 }}>
-            Detailed breakdown of your performance on each question
+          <p style={{ color: 'var(--editorial-muted)', fontSize: 14, lineHeight: 1.6 }}>
+            Detailed breakdown of your performance on each question.
           </p>
         </div>
 
-        {/* Summary Cards */}
-        <div style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fit, minmax(180px, 1fr))', gap: 16 }}>
-          <div style={cardStyle}>
-            <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--editorial-muted)', marginBottom: 4 }}>
-              Total Questions
+        {/* Summary Strip */}
+        <div style={{
+          borderTop: '1px solid var(--editorial-rule)',
+          borderBottom: '1px solid var(--editorial-rule)',
+          display: 'grid',
+          gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
+        }}>
+          {summaryCells.map((cell, i) => (
+            <div
+              key={cell.label}
+              style={{
+                padding: '24px 20px 24px 0',
+                paddingLeft: i === 0 ? 0 : 20,
+                borderRight: i < summaryCells.length - 1 ? '1px solid var(--editorial-rule)' : 'none',
+              }}
+            >
+              <span style={statLabelStyle}>{cell.label}</span>
+              <span style={statValueStyle}>{cell.value}</span>
+              {cell.helper !== undefined ? (
+                <span style={statHelperStyle}>{cell.helper}</span>
+              ) : null}
             </div>
-            <div style={{ fontSize: 28, fontWeight: 700, color: 'var(--theme-primary)' }}>
-              {summary.totalQuestions}
-            </div>
-          </div>
-
-          <div style={cardStyle}>
-            <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--editorial-muted)', marginBottom: 4 }}>
-              Questions Attempted
-            </div>
-            <div style={{ fontSize: 28, fontWeight: 700, color: 'var(--theme-purple)' }}>
-              {summary.questionsAttempted}
-            </div>
-          </div>
-
-          <div style={cardStyle}>
-            <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--editorial-muted)', marginBottom: 4 }}>
-              Mastered
-            </div>
-            <div style={{ fontSize: 28, fontWeight: 700, color: 'var(--theme-success)' }}>
-              {summary.questionsMastered}
-            </div>
-            <div style={{ fontSize: 12, color: 'var(--editorial-muted)', marginTop: 4 }}>
-              3+ consecutive correct
-            </div>
-          </div>
-
-          <div style={cardStyle}>
-            <div style={{ fontSize: 13, fontWeight: 500, color: 'var(--editorial-muted)', marginBottom: 4 }}>
-              Need Practice
-            </div>
-            <div style={{ fontSize: 28, fontWeight: 700, color: 'var(--theme-warning)' }}>
-              {summary.questionsNeedingPractice}
-            </div>
-            <div style={{ fontSize: 12, color: 'var(--editorial-muted)', marginTop: 4 }}>&lt;60% accuracy</div>
-          </div>
+          ))}
         </div>
 
         {/* Filters and Search */}
-        <div style={{ ...cardStyle, padding: 16 }}>
+        <div style={{ borderTop: '1px solid var(--editorial-rule)', paddingTop: 20 }}>
+          <p style={eyebrowStyle}>Filter · Search</p>
           <div style={{ display: 'flex', flexWrap: 'wrap', gap: 16 }}>
             <div style={{ flexShrink: 0 }}>
-              <label style={{ display: 'block', fontSize: 13, fontWeight: 500, color: 'var(--editorial-muted)', marginBottom: 4 }}>
+              <label style={{ display: 'block', fontSize: 13, fontWeight: 500, color: 'var(--editorial-muted)', marginBottom: 6 }}>
                 Filter
               </label>
               <select
@@ -205,7 +225,7 @@ export default function Statistics() {
             </div>
 
             <div style={{ flexGrow: 1, minWidth: 200 }}>
-              <label style={{ display: 'block', fontSize: 13, fontWeight: 500, color: 'var(--editorial-muted)', marginBottom: 4 }}>
+              <label style={{ display: 'block', fontSize: 13, fontWeight: 500, color: 'var(--editorial-muted)', marginBottom: 6 }}>
                 Search
               </label>
               <input
@@ -218,13 +238,13 @@ export default function Statistics() {
             </div>
           </div>
 
-          <div style={{ marginTop: 10, fontSize: 13, color: 'var(--editorial-muted)' }}>
+          <div style={{ marginTop: 12, fontSize: 13, color: 'var(--editorial-muted)' }}>
             Showing {filteredStatistics.length} of {statistics.length} questions
           </div>
         </div>
 
         {/* Statistics Table */}
-        <div style={{ backgroundColor: 'var(--theme-card-bg)', border: '1px solid var(--editorial-rule)', borderRadius: 8, overflow: 'hidden' }}>
+        <div style={{ borderTop: '1px solid var(--editorial-rule)', borderBottom: '1px solid var(--editorial-rule)' }}>
           <div style={{ overflowY: 'auto', maxHeight: 'calc(100vh - 28rem)' }}>
             <QuestionStatisticsTable
               statistics={filteredStatistics}

--- a/website/src/app/statistics/page.tsx
+++ b/website/src/app/statistics/page.tsx
@@ -12,6 +12,12 @@ import { QuestionStatistics, QuestionFilter, QuestionSortField } from '@/types'
 import type { PairedAnswers } from 'questionnaire'
 import { loadQuestions, civicsQuestionsWithDistractors } from 'questionnaire'
 
+type SummaryCell = {
+  readonly label: string
+  readonly value: number
+  readonly helper?: string
+}
+
 export default function Statistics() {
   const [statistics, setStatistics] = useState<QuestionStatistics[]>([])
   const [filteredStatistics, setFilteredStatistics] = useState<QuestionStatistics[]>([])
@@ -140,9 +146,9 @@ export default function Statistics() {
     marginTop: 6,
   }
 
-  const summaryCells = [
-    { label: 'Total Questions', value: summary.totalQuestions, helper: undefined as string | undefined },
-    { label: 'Attempted', value: summary.questionsAttempted, helper: undefined },
+  const summaryCells: ReadonlyArray<SummaryCell> = [
+    { label: 'Total Questions', value: summary.totalQuestions },
+    { label: 'Attempted', value: summary.questionsAttempted },
     { label: 'Mastered', value: summary.questionsMastered, helper: '3+ consecutive correct' },
     { label: 'Need Practice', value: summary.questionsNeedingPractice, helper: '<60% accuracy' },
   ]
@@ -174,21 +180,9 @@ export default function Statistics() {
         </div>
 
         {/* Summary Strip */}
-        <div style={{
-          borderTop: '1px solid var(--editorial-rule)',
-          borderBottom: '1px solid var(--editorial-rule)',
-          display: 'grid',
-          gridTemplateColumns: 'repeat(auto-fit, minmax(160px, 1fr))',
-        }}>
-          {summaryCells.map((cell, i) => (
-            <div
-              key={cell.label}
-              style={{
-                padding: '24px 20px 24px 0',
-                paddingLeft: i === 0 ? 0 : 20,
-                borderRight: i < summaryCells.length - 1 ? '1px solid var(--editorial-rule)' : 'none',
-              }}
-            >
+        <div className="stats-strip">
+          {summaryCells.map((cell) => (
+            <div key={cell.label} className="stats-strip-cell">
               <span style={statLabelStyle}>{cell.label}</span>
               <span style={statValueStyle}>{cell.value}</span>
               {cell.helper !== undefined ? (
@@ -267,3 +261,5 @@ export default function Statistics() {
     </Layout>
   )
 }
+// SENTINEL_1777939102
+// ZSENTINEL_1777940798

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 import Link from 'next/link'
-import { Menu, X } from 'lucide-react'
+import { Menu, X, Settings } from 'lucide-react'
 import ThemeToggle from './ThemeToggle'
 import { ErrorBoundary } from './ErrorBoundary'
 
@@ -96,6 +96,17 @@ const dividerStyles: React.CSSProperties = {
   margin: '0 4px',
 }
 
+const iconLinkStyles: React.CSSProperties = {
+  display: 'flex',
+  alignItems: 'center',
+  justifyContent: 'center',
+  padding: 6,
+  borderRadius: 4,
+  color: 'var(--editorial-muted)',
+  textDecoration: 'none',
+  transition: 'color 150ms ease',
+}
+
 const mobileMenuButtonStyles: React.CSSProperties = {
   padding: 6,
   borderRadius: 4,
@@ -178,11 +189,17 @@ export default function Layout({
                   <Link href="/results" style={navLinkStyles}>Results</Link>
                   <Link href="/statistics" style={navLinkStyles}>Statistics</Link>
                 </nav>
+                <Link href="/settings" aria-label="Settings" style={iconLinkStyles}>
+                  <Settings size={18} strokeWidth={1.5} />
+                </Link>
                 <div style={dividerStyles} />
                 <ThemeToggle />
               </div>
 
               <div className="md:hidden" style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+                <Link href="/settings" aria-label="Settings" style={iconLinkStyles}>
+                  <Settings size={18} strokeWidth={1.5} />
+                </Link>
                 <ThemeToggle />
                 <button
                   onClick={() => setMobileMenuOpen(!mobileMenuOpen)}
@@ -200,8 +217,9 @@ export default function Layout({
               <div className="md:hidden" id="mobile-menu" data-testid="mobile-menu">
                 <div style={mobileMenuStyles}>
                   <Link href="/" onClick={() => setMobileMenuOpen(false)} style={mobileNavLinkStyles}>Home</Link>
-                  <Link href="/results" onClick={() => setMobileMenuOpen(false)} style={{ ...mobileNavLinkStyles, borderBottom: 'none' }}>Results</Link>
-                  <Link href="/statistics" onClick={() => setMobileMenuOpen(false)} style={{ ...mobileNavLinkStyles, borderBottom: 'none' }}>Statistics</Link>
+                  <Link href="/results" onClick={() => setMobileMenuOpen(false)} style={mobileNavLinkStyles}>Results</Link>
+                  <Link href="/statistics" onClick={() => setMobileMenuOpen(false)} style={mobileNavLinkStyles}>Statistics</Link>
+                  <Link href="/settings" onClick={() => setMobileMenuOpen(false)} style={{ ...mobileNavLinkStyles, borderBottom: 'none' }}>Settings</Link>
                 </div>
               </div>
             ) : null}

--- a/website/src/components/StatsSummary.tsx
+++ b/website/src/components/StatsSummary.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useRef } from 'react'
+import React, { useEffect, useState } from 'react'
 import { GameStats } from '@/types'
-import { motion, useMotionValue, useTransform, animate } from 'framer-motion'
 import { TrendingUp } from 'lucide-react'
 
 interface StatsSummaryProps {
@@ -8,25 +7,27 @@ interface StatsSummaryProps {
 }
 
 function AnimatedNumber({ value, suffix = '' }: { value: number; suffix?: string }) {
-  const count = useMotionValue(0)
-  const rounded = useTransform(count, (v) => Math.round(v))
-  const ref = useRef<HTMLSpanElement>(null)
+  const [display, setDisplay] = useState(value)
 
   useEffect(() => {
-    const controls = animate(count, value, {
-      duration: 0.9,
-      ease: 'easeOut',
-    })
-    return controls.stop
-  }, [value, count])
+    const start = display
+    const delta = value - start
+    if (delta === 0) return
+    const duration = 900
+    const startedAt = performance.now()
+    let raf = 0
+    const tick = (now: number) => {
+      const t = Math.min(1, (now - startedAt) / duration)
+      const eased = 1 - Math.pow(1 - t, 3)
+      setDisplay(Math.round(start + delta * eased))
+      if (t < 1) raf = requestAnimationFrame(tick)
+    }
+    raf = requestAnimationFrame(tick)
+    return () => cancelAnimationFrame(raf)
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value])
 
-  return (
-    <motion.span ref={ref}>
-      {rounded.get() === 0 && value === 0 ? '0' : null}
-      <motion.span>{rounded}</motion.span>
-      {suffix}
-    </motion.span>
-  )
+  return <span>{display}{suffix}</span>
 }
 
 const sectionHeadingStyle: React.CSSProperties = {

--- a/website/src/components/ThemeToggle.tsx
+++ b/website/src/components/ThemeToggle.tsx
@@ -1,33 +1,18 @@
 import React from 'react'
 import { Sun, Moon } from 'lucide-react'
-import { Stack } from '@/components/tamagui'
 import { useThemeContext } from '@/components/TamaguiProvider'
-import { styled } from 'tamagui'
 
-const ThemeButton = styled(Stack, {
-  tag: 'button',
-  padding: '$2',
-  borderRadius: '$2',
-  cursor: 'pointer',
+const buttonStyles: React.CSSProperties = {
+  display: 'flex',
   alignItems: 'center',
   justifyContent: 'center',
-  backgroundColor: 'transparent',
-  borderWidth: 0,
-
-  hoverStyle: {
-    backgroundColor: '$backgroundHover',
-  },
-
-  focusStyle: {
-    outlineWidth: 2,
-    outlineColor: '$borderColorFocus',
-    outlineStyle: 'solid',
-  },
-
-  pressStyle: {
-    opacity: 0.8,
-  },
-})
+  padding: 6,
+  borderRadius: 4,
+  background: 'transparent',
+  border: 'none',
+  cursor: 'pointer',
+  color: 'var(--editorial-muted)',
+}
 
 export default function ThemeToggle() {
   const { toggleTheme } = useThemeContext()
@@ -35,13 +20,13 @@ export default function ThemeToggle() {
   // Both icons are always in the DOM. CSS classes (.theme-icon-sun / .theme-icon-moon)
   // control visibility based on the html.t_dark class set before hydration.
   return (
-    <ThemeButton onPress={toggleTheme} accessibilityLabel="Toggle theme">
+    <button onClick={toggleTheme} aria-label="Toggle theme" style={buttonStyles}>
       <span className="theme-icon-sun" style={{ color: 'var(--editorial-muted)' }}>
         <Sun size={18} strokeWidth={1.5} />
       </span>
       <span className="theme-icon-moon" style={{ color: 'var(--editorial-muted)' }}>
         <Moon size={18} strokeWidth={1.5} />
       </span>
-    </ThemeButton>
+    </button>
   )
 }

--- a/website/src/components/ThemeToggle.tsx
+++ b/website/src/components/ThemeToggle.tsx
@@ -36,7 +36,7 @@ export default function ThemeToggle() {
   // control visibility based on the html.t_dark class set before hydration.
   return (
     <ThemeButton onPress={toggleTheme} accessibilityLabel="Toggle theme">
-      <span className="theme-icon-sun" style={{ display: 'none', color: 'var(--editorial-muted)' }}>
+      <span className="theme-icon-sun" style={{ color: 'var(--editorial-muted)' }}>
         <Sun size={18} strokeWidth={1.5} />
       </span>
       <span className="theme-icon-moon" style={{ color: 'var(--editorial-muted)' }}>

--- a/website/src/services/LocalStorageService.ts
+++ b/website/src/services/LocalStorageService.ts
@@ -213,6 +213,19 @@ const getGameSettings = (): Effect.Effect<WebsiteGameSettings, never, never> => 
   })
 }
 
+const hasSavedSettings = (): Effect.Effect<boolean, never, never> => {
+  return Effect.gen(function* () {
+    if (!checkStorageAvailable()) return false
+
+    const json = yield* Effect.try({
+      try: () => localStorage.getItem(STORAGE_KEYS.GAME_SETTINGS),
+      catch: () => null
+    }).pipe(Effect.catchAll(() => Effect.succeed(null)))
+
+    return json !== null
+  })
+}
+
 const saveTtsSettings = (settings: TtsSettings): Effect.Effect<void, never, never> => {
   return Effect.gen(function* () {
     if (!checkStorageAvailable()) return
@@ -372,6 +385,7 @@ export class LocalStorageService extends Effect.Service<LocalStorageService>()(
       getGameResults,
       saveGameSettings,
       getGameSettings,
+      hasSavedSettings,
       saveTtsSettings,
       getTtsSettings,
       savePairedAnswers,
@@ -389,6 +403,7 @@ export const TestLocalStorageServiceLayer = (fn?: {
   getGameResults?: LocalStorageService['getGameResults']
   saveGameSettings?: LocalStorageService['saveGameSettings']
   getGameSettings?: LocalStorageService['getGameSettings']
+  hasSavedSettings?: LocalStorageService['hasSavedSettings']
   saveTtsSettings?: LocalStorageService['saveTtsSettings']
   getTtsSettings?: LocalStorageService['getTtsSettings']
   savePairedAnswers?: LocalStorageService['savePairedAnswers']
@@ -406,6 +421,7 @@ export const TestLocalStorageServiceLayer = (fn?: {
       getGameResults: fn?.getGameResults ?? (() => Effect.succeed([])),
       saveGameSettings: fn?.saveGameSettings ?? (() => Effect.succeed(void 0)),
       getGameSettings: fn?.getGameSettings ?? (() => Effect.succeed(DEFAULT_GAME_SETTINGS)),
+      hasSavedSettings: fn?.hasSavedSettings ?? (() => Effect.succeed(false)),
       saveTtsSettings: fn?.saveTtsSettings ?? (() => Effect.succeed(void 0)),
       getTtsSettings: fn?.getTtsSettings ?? (() => Effect.succeed(DEFAULT_TTS_SETTINGS)),
       savePairedAnswers: fn?.savePairedAnswers ?? (() => Effect.succeed(void 0)),

--- a/website/src/styles/design-tokens.css
+++ b/website/src/styles/design-tokens.css
@@ -309,6 +309,60 @@ html.t_dark {
   background-color: var(--color-error-700);
 }
 
+/* Editorial Button Variants */
+.btn-editorial {
+  background-color: var(--editorial-ink);
+  color: var(--editorial-paper);
+  border: 1px solid var(--editorial-ink);
+  border-radius: 3px;
+  padding: 12px 22px;
+  font-family: var(--font-family-serif);
+  font-size: 15px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background-color 150ms ease, color 150ms ease, border-color 150ms ease;
+}
+
+.btn-editorial:hover:not(:disabled) {
+  background-color: var(--editorial-accent);
+  border-color: var(--editorial-accent);
+}
+
+.btn-editorial:focus-visible {
+  outline: 2px solid var(--editorial-accent);
+  outline-offset: 2px;
+}
+
+.btn-editorial:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-editorial-ghost {
+  background-color: transparent;
+  color: var(--editorial-ink);
+  border: 1px solid var(--editorial-rule);
+  border-radius: 3px;
+  padding: 11px 20px;
+  font-family: var(--font-family-serif);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: border-color 150ms ease, color 150ms ease;
+}
+
+.btn-editorial-ghost:hover:not(:disabled) {
+  border-color: var(--editorial-ink);
+  color: var(--editorial-accent);
+}
+
+.btn-editorial-ghost:focus-visible {
+  outline: 2px solid var(--editorial-accent);
+  outline-offset: 2px;
+}
+
 /* Card Components */
 .card {
   background-color: var(--color-neutral-50);


### PR DESCRIPTION
## Summary

Continues the editorial style from [#40](https://github.com/talesin/civics100/pull/40) across the home, results, and statistics pages, plus a couple of small bug fixes that were blocking that polish.

- **Editorial buttons**: new `.btn-editorial` and `.btn-editorial-ghost` classes (serif Georgia, 3px radius, `--editorial-ink` ink-on-paper). Applied on the home and results pages.
- **One Start CTA**: home page collapses "Customize & Start" + "Quick Start" into a single Start button. First-time users (no `civics100_game_settings` in localStorage) route to `/settings`; returning users go straight to `/game`. Backed by a new `LocalStorageService.hasSavedSettings()` method that just checks key presence — no separate flag to drift on "Clear All Data".
- **Settings cog in header**: persistent `Settings` icon link next to the theme toggle on desktop and mobile, plus a Settings entry in the mobile menu.
- **Theme toggle fix**: removed the inline `display: 'none'` on the sun span that was clobbering `html.t_dark .theme-icon-sun { display: block }`. The toggle was invisible in dark mode (both icons hidden); now sun shows in dark and moon in light, as intended.
- **Theme toggle alignment**: replaced the Tamagui `ThemeButton` with a plain HTML button matching the cog's geometry (30×30, 6px padding, 4px radius), and switched the visible icon span to `display: flex; line-height: 0` to remove SVG baseline descent. Both icons now center on the same Y as the cog.
- **Results page polish**: dropped boxed cards for hairline rules, added an "ARCHIVE · n TESTS" eyebrow, switched per-row percentages to serif numerals, shrunk the donut stroke and used `--editorial-accent` for passing scores, and demoted "Clear all data" to a muted text link.
- **Statistics page polish**: replaced the four colored summary cards with a single hairline stats strip (4 cols → 2 → 1) using serif numerals in editorial-ink — no per-stat color coding. Filter panel and table lost their card boxes; only top/bottom hairlines remain.

### Side fix
A pre-existing rendering bug in `StatsSummary.tsx` was crashing the home and results pages whenever any test history existed: `<motion.span>{rounded}</motion.span>` doesn't render `MotionValue` children in the installed framer-motion. Rewrote `AnimatedNumber` to use a plain `requestAnimationFrame` ease-out tween into local state — same visual effect, no framer-motion dependency.

## Test plan

- [x] Lint clean (`npm run lint` from `website/`).
- [x] Manual browser walk-through:
  - First-time visit → Start routes to `/settings`.
  - After saving settings → Start routes to `/game`.
  - Theme toggle: clicking adds/removes `html.t_dark`; sun visible in dark, moon in light; both icons centered.
  - Settings cog and theme toggle: both 30×30, icons centered at identical Y in light and dark mode.
  - Results page with seeded test history: editorial card layout, serif percentages, accent-only donut for passes, muted "Clear all data" link.
  - Statistics page: eyebrow, serif h1, hairline stats strip with editorial-ink numerals (no colored boxes), borderless filter panel, clean top/bottom-rule table.
- [ ] Tests not run — pre-existing TS config errors (TS5011 rootDir / TS5107 moduleResolution) and unrelated test fixture issues fail the suite regardless of these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)